### PR TITLE
Add timeseries yaml data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
 								      "data/stis_configs/*",
 								      "data/target_metadata/*",
 								      "data/vignette_scaling/*",
-								      "data/fuse/*"
+								      "data/fuse/*",
+								      "data/timeseries/*"
 									]},
     install_requires = ["setuptools",
                         "numpy",

--- a/utils/data/timeseries/v-bp-tau.yaml
+++ b/utils/data/timeseries/v-bp-tau.yaml
@@ -1,0 +1,25 @@
+# Should sub-exposure timeseries be created?
+sub_exp_tss: True
+# Should exposure timeseries be created?
+exp_tss: True
+
+# The time and wavelength binning, if subexposure TSS are being created
+# Separated by IPPP identifiers so different bins can be used for different
+# epochs
+bins:
+    lejp:
+        g160m:
+            time: 30 # exptime is 128s
+            wave: 6
+            min_exptime: 20
+        g230l:
+            time: 10 # exptime is 196s
+            wave: 1
+            min_exptime: 8
+
+# List of bad IPPPSS identifiers, if any, so that they are not included in TSS
+bad_ipppss: null
+
+# List of IPPPSS identifiers, if any, that require wavelength offset correction,
+# and the accompanying wavelength shift file locations
+wavelength_shift: null 

--- a/utils/data/timeseries/v-gm-aur.yaml
+++ b/utils/data/timeseries/v-gm-aur.yaml
@@ -1,0 +1,26 @@
+# Should sub-exposure timeseries be created?
+sub_exp_tss: True
+# Should exposure timeseries be created?
+exp_tss: True
+
+# The time and wavelength binning, if subexposure TSS are being created
+# Separated by IPPP identifiers so different bins can be used for different
+# epochs
+bins:
+    lek7:
+        g160m:
+            time: 90 # exptime is 186s or 265s
+            wave: 6
+            min_exptime: 50
+        g230l:
+            time: 10 # exptime is 184s or 50s
+            wave: 1
+            min_exptime: 8
+
+# List of bad IPPPSS identifiers, if any, so that they are not included in TSS
+bad_ipppss:
+    - lek71f
+
+# List of IPPPSS identifiers, if any, that require wavelength offset correction,
+# and the accompanying wavelength shift file locations
+wavelength_shift: null

--- a/utils/data/timeseries/v-ru-lup.yaml
+++ b/utils/data/timeseries/v-ru-lup.yaml
@@ -1,0 +1,29 @@
+# Should sub-exposure timeseries be created?
+sub_exp_tss: True
+# Should exposure timeseries be created?
+exp_tss: True
+
+# The time and wavelength binning, if subexposure TSS are being created
+# Separated by IPPP identifiers so different bins can be used for different
+# epochs
+bins:
+    leit:
+        g160m:
+            time: 30 # exptime is 220s
+            wave: 6
+            min_exptime: 20
+        g230l:
+            time: 10 # exptime is 30s
+            wave: 1
+            min_exptime: 8
+
+# List of bad IPPPSS identifiers, if any, so that they are not included in TSS
+bad_ipppss:
+    - leit1d
+    - leitad
+    - leit1l
+
+
+# List of IPPPSS identifiers, if any, that require wavelength offset correction,
+# and the accompanying wavelength shift file locations
+wavelength_shift: null

--- a/utils/data/timeseries/v-tw-hya.yaml
+++ b/utils/data/timeseries/v-tw-hya.yaml
@@ -1,0 +1,37 @@
+# Should sub-exposure timeseries be created?
+sub_exp_tss: True
+# Should exposure timeseries be created?
+exp_tss: True
+
+# The time and wavelength binning, if subexposure TSS are being created
+# Separated by IPPP identifiers so different bins can be used for different
+# epochs
+bins:
+    le9d:
+        g160m:
+            time: 30 # exptime is 300s
+            wave: 3
+            min_exptime: 20
+        g230l:
+            time: 10 # exptime is 30s
+            wave: 1
+            min_exptime: 8
+    lepc:
+        g160m:
+            time: 30 # exptime is 300s
+            wave: 3
+            min_exptime: 20
+        g230l:
+            time: 10 # exptime is 30s
+            wave: 1
+            min_exptime: 8
+
+# List of bad IPPPSS identifiers, if any, so that they are not included in TSS
+bad_ipppss:
+    - le9d1k
+
+# List of IPPPSS identifiers, if any, that require wavelength offset correction,
+# and the accompanying wavelength shift file locations
+wavelength_shift:
+    le9d1c: "$UTILS_DIR/data/cos_shifts/twhya_shifts.txt" 
+    le9d1g: "$UTILS_DIR.data/cos_shifts/twhya_shifts.txt" 


### PR DESCRIPTION
The hardcoded parameters needed to create timeseries HLSPs for the monitoring stars was moved from ullyses.ctts_cal into these new yaml files. 

Needed to support PR in ullyses: https://github.com/spacetelescope/ullyses/pull/25