### PR TITLE
adding failed ipppss to yaml files

### DIFF
--- a/utils/data/timeseries/v-gm-aur.yaml
+++ b/utils/data/timeseries/v-gm-aur.yaml
@@ -20,6 +20,7 @@ bins:
 # List of bad IPPPSS identifiers, if any, so that they are not included in TSS
 bad_ipppss:
     - lek71f
+    - lek7ak
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
 # and the accompanying wavelength shift file locations

--- a/utils/data/timeseries/v-tw-hya.yaml
+++ b/utils/data/timeseries/v-tw-hya.yaml
@@ -29,9 +29,13 @@ bins:
 # List of bad IPPPSS identifiers, if any, so that they are not included in TSS
 bad_ipppss:
     - le9d1k
+    - lepc1d
+    - lepc1g
+    - lepc1h
+    - lepcad
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
 # and the accompanying wavelength shift file locations
 wavelength_shift:
     le9d1c: "$UTILS_DIR/data/cos_shifts/twhya_shifts.txt" 
-    le9d1g: "$UTILS_DIR.data/cos_shifts/twhya_shifts.txt" 
+    le9d1g: "$UTILS_DIR/data/cos_shifts/twhya_shifts.txt" 


### PR DESCRIPTION
Initial changes to the gm-aur and tw-hya yaml files to add new failed visits to the bad_ipppss list. I haven't fiddled with binning yet so these might change again.