### PR TITLE
Additional DR5b updates

### DIFF
--- a/utils/data/stis_configs/sz100_g230l.yaml
+++ b/utils/data/stis_configs/sz100_g230l.yaml
@@ -1,17 +1,17 @@
 force_dq16: False 
 infile: 
-  'oet61s010_flt.fits':
-    targets:
-      SZ100:
-        x1d:
-          yloc: null # null values mean to use the default parameters
-          height: 7
-          maxsrch: null
-          xoffset: null
-          b_bkg1: null
-          b_bkg2: null
-          b_hgt1: null
-          b_hgt2: null
+#  'oet61s010_flt.fits':
+#    targets:
+#      SZ100:
+#        x1d:
+#          yloc: null # null values mean to use the default parameters
+#          height: 7
+#          maxsrch: null
+#          xoffset: null
+#          b_bkg1: null
+#          b_bkg2: null
+#          b_hgt1: null
+#          b_hgt2: null
   'oet6as010_flt.fits':
     targets:
       SZ100:

--- a/utils/data/stis_configs/sz100_g430l.yaml
+++ b/utils/data/stis_configs/sz100_g430l.yaml
@@ -1,17 +1,17 @@
 force_dq16: True 
 infile: 
-  'oet61s060_crj.fits':
-    targets:
-      SZ100:            
-        x1d:
-          yloc: null 
-          height: 5
-          maxsrch: null
-          xoffset: null
-          b_bkg1: null
-          b_bkg2: null
-          b_hgt1: null
-          b_hgt2: null
+#  'oet61s060_crj.fits':
+#    targets:
+#      SZ100:            
+#        x1d:
+#          yloc: null 
+#          height: 5
+#          maxsrch: null
+#          xoffset: null
+#          b_bkg1: null
+#          b_bkg2: null
+#          b_hgt1: null
+#          b_hgt2: null
   'oet6as060_crj.fits': 
     targets: 
       SZ100:             

--- a/utils/data/stis_configs/sz100_g750l.yaml
+++ b/utils/data/stis_configs/sz100_g750l.yaml
@@ -1,32 +1,32 @@
 force_dq16: True 
 infile: 
-  'oet61s020_crj.fits':
-    targets:
-      SZ100:            
-        x1d:
-          yloc: null # null values mean to use the default parameters
-          height: 5
-          maxsrch: null
-          xoffset: null
-          b_bkg1: null
-          b_bkg2: null
-          b_hgt1: null
-          b_hgt2: null
-        do_defringe: True
-        defringe:
-          fringeflat: 'oet61s030_raw.fits'
-          do_shift: True
-          beg_shift: -0.5
-          end_shift: 1.5
-          shift_step: 0.1
-          do_scale: true
-          beg_scale: 0.8
-          end_scale: 1.5
-          scale_step: 0.04
-          opti_spreg: null
-          rms_region: null
-          extrloc: null
-          extrsize: null
+#  'oet61s020_crj.fits':
+#    targets:
+#      SZ100:            
+#        x1d:
+#          yloc: null # null values mean to use the default parameters
+#          height: 5
+#          maxsrch: null
+#          xoffset: null
+#          b_bkg1: null
+#          b_bkg2: null
+#          b_hgt1: null
+#          b_hgt2: null
+#        do_defringe: True
+#        defringe:
+#          fringeflat: 'oet61s030_raw.fits'
+#          do_shift: True
+#          beg_shift: -0.5
+#          end_shift: 1.5
+#          shift_step: 0.1
+#          do_scale: true
+#          beg_scale: 0.8
+#          end_scale: 1.5
+#          scale_step: 0.04
+#          opti_spreg: null
+#          rms_region: null
+#          extrloc: null
+#          extrsize: null
 
   'oet6as020_crj.fits':
     targets:

--- a/utils/data/stis_configs/sz115_g140l.yaml
+++ b/utils/data/stis_configs/sz115_g140l.yaml
@@ -1,0 +1,95 @@
+# First define all detector-wide corrections
+# Set force_dq16 to True if you want to manually calculate DQ=16 even when 
+# less than 6% of detector is flagged as so
+# This can be True for CCD, but should be False for MAMA
+force_dq16: False 
+
+# The input filename. For CCD this will be a CRJ, for MAMA, an FLT.
+infile: 
+    'oesr2s010_flt.fits':
+        # Now define all target-specific corrections and parameters.
+        # First the science target- replace 'ullyses_name' with the target name.
+        # YOU MUST USE THE OFFICIAL ULLYSES NAME BELOW.
+        targets:
+            sz115:
+                # Extraction parameters. For default values, leave as null
+                x1d:
+                    yloc: null  # null values mean to use the default parameters
+                    height: null
+                    maxsrch: null
+                    xoffset: null
+                    b_bkg1: null
+                    b_bkg2: null
+                    b_hgt1: null
+                    b_hgt2: null
+
+    'oesr2s020_flt.fits':
+        targets:
+            sz115:
+                # Extraction parameters. For default values, leave as null
+                x1d:
+                    yloc: null  # null values mean to use the default parameters
+                    height: null
+                    maxsrch: null
+                    xoffset: null
+                    b_bkg1: null
+                    b_bkg2: null
+                    b_hgt1: null
+                    b_hgt2: null
+
+    'oesr2s030_flt.fits':
+        targets:
+            sz115:
+                # Extraction parameters. For default values, leave as null
+                x1d:
+                    yloc: null  # null values mean to use the default parameters
+                    height: null
+                    maxsrch: null
+                    xoffset: null
+                    b_bkg1: null
+                    b_bkg2: null
+                    b_hgt1: null
+                    b_hgt2: null
+
+    'oesr2u010_flt.fits':
+        targets:
+            sz115:
+                # Extraction parameters. For default values, leave as null
+                x1d:
+                    yloc: null  # null values mean to use the default parameters
+                    height: null
+                    maxsrch: null
+                    xoffset: null
+                    b_bkg1: null
+                    b_bkg2: null
+                    b_hgt1: null
+                    b_hgt2: null
+
+    'oesr2u020_flt.fits':
+        targets:
+            sz115:
+                # Extraction parameters. For default values, leave as null
+                x1d:
+                    yloc: null  # null values mean to use the default parameters
+                    height: null
+                    maxsrch: null
+                    xoffset: null
+                    b_bkg1: null
+                    b_bkg2: null
+                    b_hgt1: null
+                    b_hgt2: null
+
+    'oesr2u030_flt.fits':
+        targets:
+            sz115:
+                # Extraction parameters. For default values, leave as null
+                x1d:
+                    yloc: 409  # null values mean to use the default parameters
+                    height: null
+                    maxsrch: 10
+                    xoffset: null
+                    b_bkg1: null
+                    b_bkg2: null
+                    b_hgt1: null
+                    b_hgt2: null
+


### PR DESCRIPTION
I added a config file for SZ115 STIS/G140L data based on Dick's evaluation: https://jira.stsci.edu/browse/ULLYSES-1446
There were two good epochs of STIS data for target SZ100. However, the intrinsic flux changed between those 2 epochs, and therefore we cannot coadd the data. Therefore one of the epochs is commented out in the config files. 
