### PR TITLE
Reformat TTS config files

### DIFF
--- a/utils/data/timeseries/v-bp-tau.yaml
+++ b/utils/data/timeseries/v-bp-tau.yaml
@@ -89,8 +89,8 @@ good_files:
 # You may specify either IPPPSS or IPPPSSOOT identifiers.      
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.
 bad_files:
-    - lepd1g
-    - lepd1hzsq
+    - lepd1g     # Failed TA, no data
+    - lepd1hzsq  # Failed TA, but observations appear successful; this exp has a large wavelength shift so excluding
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
 # and the accompanying wavelength shift file locations.

--- a/utils/data/timeseries/v-bp-tau.yaml
+++ b/utils/data/timeseries/v-bp-tau.yaml
@@ -1,9 +1,9 @@
 # The name of this file should be the *ULLYSES DP TARGET NAME IN LOWERCASE*!!!
 # E.g. for TW Hydra the file name should be v-tw-hya.yaml
 
-# Should sub-exposure timeseries be created?
+# True if sub-exposure timeseries be created
 sub_exp_tss: True
-# Should exposure timeseries be created?
+# True if exposure timeseries be created
 exp_tss: True
 
 # Provide the observing configuration
@@ -52,7 +52,35 @@ bins:
 #
 # You may specify either IPPPSS or IPPPSSOOT identifiers.
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.
-good_files: null
+good_files:
+    - lejp1c
+    - lejp1d
+    - lejp1e
+    - lejp1f
+    - lejp1g
+    - lejp1h
+    - lejp1i
+    - lejp1j
+    - lejp1k
+    - lejp1l
+    - lejp1m
+    - lejp1n
+    - lepd1c
+    - lepd1d
+    - lepd1e
+    - lepd1f
+    - lepd1ha1q
+    - lepd1hzqq
+    - lepd1hzwq
+    - lepd1ha4q
+    - lepd1hzyq
+    - lepd1i
+    - lepd1j
+    - lepd1k
+    - lepd1l
+    - lepd1m
+    - lepd1n
+    - lepdag
 
 # If you want to specify the list of exposures *NOT TO USE*, list them below
 # with the bad_files variable. Otherwise set bad_files to None by using

--- a/utils/data/timeseries/v-gm-aur.yaml
+++ b/utils/data/timeseries/v-gm-aur.yaml
@@ -51,7 +51,29 @@ bins:
 #
 # You may specify either IPPPSS or IPPPSSOOT identifiers.
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.
-good_files: null
+good_files:
+    - lek71c
+    - lek71d
+    - lek71e
+    - lek71f
+    - lek71g
+    - lek71h
+    - lek71i
+    - lek7aj
+    - lek7al
+    - lek7am
+    - lek7an
+    - lepg1c
+    - lepg1d
+    - lepg1e
+    - lepg1f
+    - lepg1g
+    - lepg1h
+    - lepg1i
+    - lepg1j
+    - lepg1k
+    - lepg1l
+    - lepg1m
 
 # If you want to specify the list of exposures *NOT TO USE*, list them below
 # with the bad_files variable. Otherwise set bad_files to None by using

--- a/utils/data/timeseries/v-gm-aur.yaml
+++ b/utils/data/timeseries/v-gm-aur.yaml
@@ -82,13 +82,13 @@ good_files:
 # You may specify either IPPPSS or IPPPSSOOT identifiers.      
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.
 bad_files:
-    - lek71j
-    - lek71k
-    - lek71l
-    - lek71m
-    - lek71n
-    - lek7ak
-    - lepg1n
+    - lek71j  # failed due to HST safing issue
+    - lek71k  # failed due to HST safing issue
+    - lek71l  # failed due to HST safing issue
+    - lek71m  # failed due to HST safing issue
+    - lek71n  # failed due to HST safing issue
+    - lek7ak  # Failed ACQ, shutter closed for observations, no data
+    - lepg1n  # TA Failed, No data
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
 # and the accompanying wavelength shift file locations.

--- a/utils/data/timeseries/v-ru-lup.yaml
+++ b/utils/data/timeseries/v-ru-lup.yaml
@@ -82,11 +82,11 @@ good_files:
 # You may specify either IPPPSS or IPPPSSOOT identifiers.      
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.
 bad_files:
-    - leit1d
-    - leitad
-    - leit1l
-    - leph1d
-    - leph1e
+    - leit1d  # Failed ACQ, shutter open for observation, but data bad
+    - leitad  # Failed ACQ, shutter closed for observations, no data
+    - leit1l  # Failed ACQ, shutter closed for observations, no data
+    - leph1d  # Failed TA, target off-centered, bad data
+    - leph1e  # Failed TA, shutter closed for observations, no data
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
 # and the accompanying wavelength shift file locations.

--- a/utils/data/timeseries/v-ru-lup.yaml
+++ b/utils/data/timeseries/v-ru-lup.yaml
@@ -1,9 +1,9 @@
 # The name of this file should be the *ULLYSES DP TARGET NAME IN LOWERCASE*!!!
 # E.g. for TW Hydra the file name should be v-tw-hya.yaml
 
-# Should sub-exposure timeseries be created?
+# True if sub-exposure timeseries be created
 sub_exp_tss: True
-# Should exposure timeseries be created?
+# True if exposure timeseries be created
 exp_tss: True
 
 # Provide the observing configuration
@@ -12,6 +12,7 @@ instrument: cos # This is a single value
 gratings: # This is a list
     - g160m
     - g230l
+
 # If no subexposure TSS are being created, you may leave the section below
 # with default values or you may set bins equal to None by using:
 # bins: null
@@ -50,7 +51,29 @@ bins:
 #
 # You may specify either IPPPSS or IPPPSSOOT identifiers.
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.
-good_files: null
+good_files:
+    - leit1c
+    - leit1e
+    - leit1f
+    - leit1g
+    - leit1h
+    - leit1i
+    - leit1j
+    - leit1k
+    - leit1m
+    - leit1n
+    - leph1c
+    - leit1f
+    - leit1g
+    - leit1h
+    - leit1i
+    - leit1j
+    - leit1k
+    - leit1l
+    - leit1m
+    - leit1n
+    - leitad
+    - leitae
 
 # If you want to specify the list of exposures *NOT TO USE*, list them below
 # with the bad_files variable. Otherwise set bad_files to None by using

--- a/utils/data/timeseries/v-tw-hya.yaml
+++ b/utils/data/timeseries/v-tw-hya.yaml
@@ -79,12 +79,12 @@ bins:
 #
 # You may specify either IPPPSS or IPPPSSOOT identifiers.
 # You MUST use a dash+space, which tells yaml the value is actually part of a list.bad_files:
-    - le9d1k
-    - lepc1d
-    - lepc1g # exptime=0
-    - lepc1h
-    - lepcad
-    - lepcah # exptime=0
+    - le9d1k  # Failed TA, target well outside aperture. Failed visit
+    - lepc1d  # Bad TA, shutter open, bad data
+    - lepc1g  # Bad TA, shutter closed, no data
+    - lepc1h  # Bad TA, shutter closed, no data
+    - lepcad  # Bad TA, shutter closed, no data
+    - lepcah  # Bad TA, shutter closed, no data
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
 # and the accompanying wavelength shift file locations.

--- a/utils/data/timeseries/v-tw-hya.yaml
+++ b/utils/data/timeseries/v-tw-hya.yaml
@@ -1,19 +1,23 @@
 # The name of this file should be the *ULLYSES DP TARGET NAME IN LOWERCASE*!!!
 # E.g. for TW Hydra the file name should be v-tw-hya.yaml
 
-# Should sub-exposure timeseries be created?
+# True if sub-exposure timeseries be created
 sub_exp_tss: True
-# Should exposure timeseries be created?
+# True if exposure timeseries be created
 exp_tss: True
 
+# Provide the observing configuration
 observatory: hst # This is a single value
 instrument: cos # This is a single value
 gratings: # This is a list
     - g160m
     - g230l
 
-
-# The time and wavelength binning, if subexposure TSS are being created
+# If no subexposure TSS are being created, you may leave the section below
+# with default values or you may set bins equal to None by using:
+# bins: null
+#
+# If subexposure TSS are being created, specify the time and wavelength binning.
 # Separated by IPPP identifiers so different bins can be used for different
 # epochs
 bins:
@@ -36,10 +40,45 @@ bins:
             wave: 1
             min_exptime: 8
 
-good_files: null
+# We have two ways of indicating which exact exposures should be turned into a
+# timeseries: we can either specify which files to use, or which files *NOT*
+# to use. For monitoring stars, it's easier to do the latter, but for
+# serendipitous TSS, it's easier to do the former.
+#
+# If you want to specify the list of exposure *TO USE*, list them below with the
+# good_files variable. Otherwise set good_files to None by using:
+# good_files: null
+#
+# You may specify either IPPPSS or IPPPSSOOT identifiers.
+# You MUST use a dash+space, which tells yaml the value is actually part of a list.good_files:
+    - le9d1c
+    - le9d1d
+    - le9d1e
+    - le9d1f
+    - le9d1g
+    - le9d1h
+    - le9d1i
+    - le9d1j
+    - le9d1l
+    - le9d1m
+    - le9d1n
+    - lepc1c
+    - lepc1e
+    - lepc1f
+    - lepc1i
+    - lepc1j
+    - lepc1k
+    - lepc1l
+    - lepc1m
+    - lepc1n
+    - lepcag
 
-# List of bad IPPPSS or IPPPSSOOT identifiers, if any
-bad_files:
+# If you want to specify the list of exposures *NOT TO USE*, list them below
+# with the bad_files variable. Otherwise set bad_files to None by using
+# bad_files: null
+#
+# You may specify either IPPPSS or IPPPSSOOT identifiers.
+# You MUST use a dash+space, which tells yaml the value is actually part of a list.bad_files:
     - le9d1k
     - lepc1d
     - lepc1g # exptime=0
@@ -48,7 +87,9 @@ bad_files:
     - lepcah # exptime=0
 
 # List of IPPPSS identifiers, if any, that require wavelength offset correction,
-# and the accompanying wavelength shift file locations
+# and the accompanying wavelength shift file locations.
+# If no files require a shift, you can set wavelength_shift to None by using:
+# wavelength_shift: null
 wavelength_shift:
     le9d1c: "$UTILS_DIR/data/cos_shifts/v-tw-hya_shifts.txt"
     le9d1g: "$UTILS_DIR/data/cos_shifts/v-tw-hya_shifts.txt"


### PR DESCRIPTION
Changed the timeseries config files for RU LUP, TW HYA, BP TAU, and GM AUR to use both good_files and bad_files, and explain why the bad files are excluded. There are also a few minor changes to the comment text -- I used sz45.yaml as the template for the comments.