### PR TITLE
Add missing YAML files for DR7 targets that used default CCD pars

### DIFF
--- a/utils/data/stis_configs/2dfs-3689_g230lb_archival.yaml
+++ b/utils/data/stis_configs/2dfs-3689_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec678020_crj.fits:
+    targets:
+      2dfs-3689:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/2dfs-3689_g430l_archival.yaml
+++ b/utils/data/stis_configs/2dfs-3689_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec678010_crj.fits:
+    targets:
+      2dfs-3689:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/2dfs-3947_g230lb_archival.yaml
+++ b/utils/data/stis_configs/2dfs-3947_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec677020_crj.fits:
+    targets:
+      2dfs-3947:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/2dfs-3947_g430l_archival.yaml
+++ b/utils/data/stis_configs/2dfs-3947_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec677010_crj.fits:
+    targets:
+      2dfs-3947:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/2dfs-3954_g230lb_archival.yaml
+++ b/utils/data/stis_configs/2dfs-3954_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec616020_crj.fits:
+    targets:
+      2dfs-3954:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/2dfs-3954_g430l_archival.yaml
+++ b/utils/data/stis_configs/2dfs-3954_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec616010_crj.fits:
+    targets:
+      2dfs-3954:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/2mass-j04390163p2336029_g230l_archival.yaml
+++ b/utils/data/stis_configs/2mass-j04390163p2336029_g230l_archival.yaml
@@ -1,0 +1,24 @@
+# The input filename. For CCD this will be a CRJ, for MAMA, an FLT.
+infile: 'ob6b33020_flt.fits'
+
+# First define all detector-wide corrections
+# Set force_dq16 to True if you want to manually calculate DQ=16 even when
+# less than 6% of detector is flagged as so
+# This can be True for CCD, but should be False for MAMA
+force_dq16: False
+
+# Now define all target-specific corrections and parameters.
+# First the science target- replace 'ullyses_name' with the target name.
+# YOU MUST USE THE OFFICIAL ULLYSES NAME BELOW.
+targets:
+    2MASS-J04390163P2336029:
+        # Extraction parameters. For default values, leave as null
+        x1d:
+            yloc: 489 # null values mean to use the default parameters
+            height: null
+            maxsrch: 0
+            xoffset: null
+            b_bkg1: null
+            b_bkg2: null
+            b_hgt1: null
+            b_hgt2: null

--- a/utils/data/stis_configs/av-16_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-16_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec663020_crj.fits:
+    targets:
+      av-16:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-16_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-16_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec663010_crj.fits:
+    targets:
+      av-16:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-187_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-187_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec687020_crj.fits:
+    targets:
+      av-187:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-187_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-187_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec687010_crj.fits:
+    targets:
+      av-187:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-200_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-200_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec696010_crj.fits:
+    targets:
+      av-200:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-242_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-242_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec653020_crj.fits:
+    targets:
+      av-242:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-242_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-242_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec653010_crj.fits:
+    targets:
+      av-242:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-261_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-261_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec681020_crj.fits:
+    targets:
+      av-261:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-261_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-261_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec681010_crj.fits:
+    targets:
+      av-261:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-264_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-264_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec669020_crj.fits:
+    targets:
+      av-264:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-264_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-264_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec669010_crj.fits:
+    targets:
+      av-264:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-304_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-304_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec665020_crj.fits:
+    targets:
+      av-304:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-304_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-304_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec665010_crj.fits:
+    targets:
+      av-304:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-307_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-307_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec644020_crj.fits:
+    targets:
+      av-307:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-307_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-307_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec644010_crj.fits:
+    targets:
+      av-307:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-314_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-314_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec691010_crj.fits:
+    targets:
+      av-314:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-324_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-324_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec690010_crj.fits:
+    targets:
+      av-324:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-343_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-343_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec694010_crj.fits:
+    targets:
+      av-343:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-374_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-374_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec682020_crj.fits:
+    targets:
+      av-374:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-374_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-374_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec682010_crj.fits:
+    targets:
+      av-374:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-388_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-388_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec608020_crj.fits:
+    targets:
+      av-388:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-388_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-388_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec608010_crj.fits:
+    targets:
+      av-388:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-393_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-393_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec680020_crj.fits:
+    targets:
+      av-393:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-393_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-393_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec680010_crj.fits:
+    targets:
+      av-393:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-410_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-410_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec658020_crj.fits:
+    targets:
+      av-410:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-410_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-410_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec658010_crj.fits:
+    targets:
+      av-410:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-423_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-423_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec646020_crj.fits:
+    targets:
+      av-423:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-423_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-423_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec646010_crj.fits:
+    targets:
+      av-423:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-445_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-445_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec692010_crj.fits:
+    targets:
+      av-445:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-476_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-476_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec614020_crj.fits:
+    targets:
+      av-476:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-476_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-476_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec614010_crj.fits:
+    targets:
+      av-476:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-490_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-490_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec684020_crj.fits:
+    targets:
+      av-490:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-490_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-490_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec684010_crj.fits:
+    targets:
+      av-490:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-61_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-61_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec612020_crj.fits:
+    targets:
+      av-61:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-61_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-61_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec612010_crj.fits:
+    targets:
+      av-61:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-69_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-69_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec626020_crj.fits:
+    targets:
+      av-69:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-69_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-69_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec626010_crj.fits:
+    targets:
+      av-69:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-70_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-70_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec639020_crj.fits:
+    targets:
+      av-70:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-70_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-70_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec639010_crj.fits:
+    targets:
+      av-70:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-75_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-75_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec609020_crj.fits:
+    targets:
+      av-75:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-75_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-75_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec609010_crj.fits:
+    targets:
+      av-75:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-80_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-80_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec624020_crj.fits:
+    targets:
+      av-80:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-80_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-80_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec624010_crj.fits:
+    targets:
+      av-80:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-83_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-83_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec619020_crj.fits:
+    targets:
+      av-83:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-83_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-83_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec619010_crj.fits:
+    targets:
+      av-83:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-95_g230lb_archival.yaml
+++ b/utils/data/stis_configs/av-95_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec625020_crj.fits:
+    targets:
+      av-95:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/av-95_g430l_archival.yaml
+++ b/utils/data/stis_configs/av-95_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec625010_crj.fits:
+    targets:
+      av-95:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/bat99-105_g230lb_archival.yaml
+++ b/utils/data/stis_configs/bat99-105_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec698020_crj.fits:
+    targets:
+      bat99-105:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/bat99-105_g430l_archival.yaml
+++ b/utils/data/stis_configs/bat99-105_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec698010_crj.fits:
+    targets:
+      bat99-105:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/bi-237_g430l_archival.yaml
+++ b/utils/data/stis_configs/bi-237_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60i010_crj.fits:
+    targets:
+      bi-237:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/farina-88_g230lb_archival.yaml
+++ b/utils/data/stis_configs/farina-88_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60w020_crj.fits:
+    targets:
+      farina-88:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/farina-88_g430l_archival.yaml
+++ b/utils/data/stis_configs/farina-88_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60w010_crj.fits:
+    targets:
+      farina-88:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/lh-114-7_g230lb_archival.yaml
+++ b/utils/data/stis_configs/lh-114-7_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60m020_crj.fits:
+    targets:
+      lh-114-7:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/lh-114-7_g430l_archival.yaml
+++ b/utils/data/stis_configs/lh-114-7_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60m010_crj.fits:
+    targets:
+      lh-114-7:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/lmce078-1_g230lb_archival.yaml
+++ b/utils/data/stis_configs/lmce078-1_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61c020_crj.fits:
+    targets:
+      lmce078-1:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/lmce078-1_g430l_archival.yaml
+++ b/utils/data/stis_configs/lmce078-1_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61c010_crj.fits:
+    targets:
+      lmce078-1:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-020_g230lb_archival.yaml
+++ b/utils/data/stis_configs/n11-els-020_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61a020_crj.fits:
+    targets:
+      n11-els-020:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-020_g430l_archival.yaml
+++ b/utils/data/stis_configs/n11-els-020_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61a010_crj.fits:
+    targets:
+      n11-els-020:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-031_g230lb_archival.yaml
+++ b/utils/data/stis_configs/n11-els-031_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60c020_crj.fits:
+    targets:
+      n11-els-031:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-031_g430l_archival.yaml
+++ b/utils/data/stis_configs/n11-els-031_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60c010_crj.fits:
+    targets:
+      n11-els-031:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-038_g230lb_archival.yaml
+++ b/utils/data/stis_configs/n11-els-038_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61d020_crj.fits:
+    targets:
+      n11-els-038:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-038_g430l_archival.yaml
+++ b/utils/data/stis_configs/n11-els-038_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61d010_crj.fits:
+    targets:
+      n11-els-038:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-051_g230lb_archival.yaml
+++ b/utils/data/stis_configs/n11-els-051_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61i020_crj.fits:
+    targets:
+      n11-els-051:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-051_g430l_archival.yaml
+++ b/utils/data/stis_configs/n11-els-051_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61i010_crj.fits:
+    targets:
+      n11-els-051:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n11-els-060_g230lb_archival.yaml
+++ b/utils/data/stis_configs/n11-els-060_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60p020_crj.fits:
+    targets:
+      n11-els-060:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n206-fs-170_g230lb_archival.yaml
+++ b/utils/data/stis_configs/n206-fs-170_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63k020_crj.fits:
+    targets:
+      n206-fs-170:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/n206-fs-170_g430l_archival.yaml
+++ b/utils/data/stis_configs/n206-fs-170_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63k010_crj.fits:
+    targets:
+      n206-fs-170:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc330-els-002_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc330-els-002_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec688010_crj.fits:
+    targets:
+      ngc330-els-002:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc330-els-004_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc330-els-004_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec685010_crj.fits:
+    targets:
+      ngc330-els-004:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-026_g230lb_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-026_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec660020_crj.fits:
+    targets:
+      ngc346-els-026:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-026_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-026_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec660010_crj.fits:
+    targets:
+      ngc346-els-026:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-035_g230lb_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-035_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec679020_crj.fits:
+    targets:
+      ngc346-els-035:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-035_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-035_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec679010_crj.fits:
+    targets:
+      ngc346-els-035:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-043_g230lb_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-043_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec666020_crj.fits:
+    targets:
+      ngc346-els-043:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-043_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-043_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec666010_crj.fits:
+    targets:
+      ngc346-els-043:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-050_g230lb_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-050_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec636020_crj.fits:
+    targets:
+      ngc346-els-050:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-els-050_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc346-els-050_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec636010_crj.fits:
+    targets:
+      ngc346-els-050:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-mpg-368_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc346-mpg-368_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec611010_crj.fits:
+    targets:
+      ngc346-mpg-368:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-mpg-435_g230lb_archival.yaml
+++ b/utils/data/stis_configs/ngc346-mpg-435_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec604020_crj.fits:
+    targets:
+      ngc346-mpg-435:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/ngc346-mpg-435_g430l_archival.yaml
+++ b/utils/data/stis_configs/ngc346-mpg-435_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec604010_crj.fits:
+    targets:
+      ngc346-mpg-435:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-179_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-179_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec695010_crj.fits:
+    targets:
+      sk-179:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-65d22_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-65d22_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61n020_crj.fits:
+    targets:
+      sk-65d22:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-65d22_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-65d22_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61n010_crj.fits:
+    targets:
+      sk-65d22:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-65d47_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-65d47_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60v020_crj.fits:
+    targets:
+      sk-65d47:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-65d47_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-65d47_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60v010_crj.fits:
+    targets:
+      sk-65d47:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-66d100_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-66d100_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61q020_crj.fits:
+    targets:
+      sk-66d100:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-66d100_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-66d100_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61q010_crj.fits:
+    targets:
+      sk-66d100:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-66d18_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-66d18_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61s020_crj.fits:
+    targets:
+      sk-66d18:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-66d18_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-66d18_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61s010_crj.fits:
+    targets:
+      sk-66d18:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d106_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-67d106_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62z020_crj.fits:
+    targets:
+      sk-67d106:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d106_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d106_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62z010_crj.fits:
+    targets:
+      sk-67d106:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d191_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-67d191_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62k020_crj.fits:
+    targets:
+      sk-67d191:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d191_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d191_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62k010_crj.fits:
+    targets:
+      sk-67d191:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d195_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d195_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63t010_crj.fits:
+    targets:
+      sk-67d195:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d197_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d197_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63u010_crj.fits:
+    targets:
+      sk-67d197:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d211_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-67d211_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60f020_crj.fits:
+    targets:
+      sk-67d211:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d211_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d211_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60f010_crj.fits:
+    targets:
+      sk-67d211:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d261_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-67d261_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62f020_crj.fits:
+    targets:
+      sk-67d261:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d261_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d261_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62f010_crj.fits:
+    targets:
+      sk-67d261:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d5_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-67d5_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62m020_crj.fits:
+    targets:
+      sk-67d5:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-67d5_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-67d5_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62m010_crj.fits:
+    targets:
+      sk-67d5:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-68d26_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-68d26_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63m020_crj.fits:
+    targets:
+      sk-68d26:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-68d26_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-68d26_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63m010_crj.fits:
+    targets:
+      sk-68d26:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-69d279_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-69d279_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62l020_crj.fits:
+    targets:
+      sk-69d279:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-69d279_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-69d279_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62l010_crj.fits:
+    targets:
+      sk-69d279:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-70d16_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-70d16_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63p010_crj.fits:
+    targets:
+      sk-70d16:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-70d69_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-70d69_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61g020_crj.fits:
+    targets:
+      sk-70d69:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-70d69_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-70d69_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61g010_crj.fits:
+    targets:
+      sk-70d69:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-70d79_g230lb_archival.yaml
+++ b/utils/data/stis_configs/sk-70d79_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63b020_crj.fits:
+    targets:
+      sk-70d79:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-70d79_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-70d79_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec63b010_crj.fits:
+    targets:
+      sk-70d79:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sk-71d50_g430l_archival.yaml
+++ b/utils/data/stis_configs/sk-71d50_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61r010_crj.fits:
+    targets:
+      sk-71d50:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/sstc2d-j160830m382827_g430l_archival.yaml
+++ b/utils/data/stis_configs/sstc2d-j160830m382827_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  od7g03010_crj.fits:
+    targets:
+      sstc2d-j160830m382827:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/st92-4-18_g230lb_archival.yaml
+++ b/utils/data/stis_configs/st92-4-18_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61b020_crj.fits:
+    targets:
+      st92-4-18:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/st92-4-18_g430l_archival.yaml
+++ b/utils/data/stis_configs/st92-4-18_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61b010_crj.fits:
+    targets:
+      st92-4-18:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/st92-5-27_g230lb_archival.yaml
+++ b/utils/data/stis_configs/st92-5-27_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60q020_crj.fits:
+    targets:
+      st92-5-27:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/st92-5-27_g430l_archival.yaml
+++ b/utils/data/stis_configs/st92-5-27_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60q010_crj.fits:
+    targets:
+      st92-5-27:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-cw-tau_g750m_archival.yaml
+++ b/utils/data/stis_configs/v-cw-tau_g750m_archival.yaml
@@ -1,0 +1,29 @@
+force_dq16: true
+infile:
+  o6md01010_crj.fits:
+    targets:
+      v-cw-tau:
+        defringe:
+          beg_scale: 0.8
+          beg_shift: -0.5
+          do_scale: true
+          do_shift: true
+          end_scale: 1.2
+          end_shift: 0.5
+          extrloc: null
+          extrsize: null
+          fringeflat: rootname_raw.fits
+          opti_spreg: null
+          rms_region: null
+          scale_step: 0.04
+          shift_step: 0.1
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-dg-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-dg-tau_g430l_archival.yaml
@@ -1,0 +1,41 @@
+force_dq16: true
+infile:
+  o5e307030_crj.fits:
+    targets:
+      v-dg-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  obic01010_crj.fits:
+    targets:
+      v-dg-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  oc0n01010_crj.fits:
+    targets:
+      v-dg-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-dg-tau_g750m_archival.yaml
+++ b/utils/data/stis_configs/v-dg-tau_g750m_archival.yaml
@@ -1,0 +1,56 @@
+force_dq16: true
+infile:
+  obic02010_crj.fits:
+    targets:
+      v-dg-tau:
+        defringe:
+          beg_scale: 0.8
+          beg_shift: -0.5
+          do_scale: true
+          do_shift: true
+          end_scale: 1.2
+          end_shift: 0.5
+          extrloc: null
+          extrsize: null
+          fringeflat: rootname_raw.fits
+          opti_spreg: null
+          rms_region: null
+          scale_step: 0.04
+          shift_step: 0.1
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  oc0n02010_crj.fits:
+    targets:
+      v-dg-tau:
+        defringe:
+          beg_scale: 0.8
+          beg_shift: -0.5
+          do_scale: true
+          do_shift: true
+          end_scale: 1.2
+          end_shift: 0.5
+          extrloc: null
+          extrsize: null
+          fringeflat: rootname_raw.fits
+          opti_spreg: null
+          rms_region: null
+          scale_step: 0.04
+          shift_step: 0.1
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-ry-lup_g230mb_archival.yaml
+++ b/utils/data/stis_configs/v-ry-lup_g230mb_archival.yaml
@@ -1,0 +1,41 @@
+force_dq16: true
+infile:
+  o5b402010_crj.fits:
+    targets:
+      v-ry-lup:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  o5b402020_crj.fits:
+    targets:
+      v-ry-lup:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  o5b402030_crj.fits:
+    targets:
+      v-ry-lup:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-ry-lup_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-ry-lup_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  od2v01010_crj.fits:
+    targets:
+      v-ry-lup:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-t-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-t-tau_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  o5e304030_crj.fits:
+    targets:
+      v-t-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-tw-hya_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-tw-hya_g430l_archival.yaml
@@ -1,0 +1,80 @@
+force_dq16: true
+infile:
+  o59d01010_crj.fits:
+    targets:
+      v-tw-hya:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  o6cv03010_crj.fits:
+    targets:
+      v-tw-hya:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  ob3r07010_crj.fits:
+    targets:
+      v-tw-hya:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  ob3r08010_crj.fits:
+    targets:
+      v-tw-hya:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  ob3r09010_crj.fits:
+    targets:
+      v-tw-hya:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null
+  oclv03030_crj.fits:
+    targets:
+      v-tw-hya:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-v1070-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-v1070-tau_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  o8ns03010_crj.fits:
+    targets:
+      v-v1070-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-v1098-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-v1098-tau_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  o8ns01010_crj.fits:
+    targets:
+      v-v1098-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-v410-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-v410-tau_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  o5e308030_crj.fits:
+    targets:
+      v-v410-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-v826-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-v826-tau_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  o8ns05010_crj.fits:
+    targets:
+      v-v826-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/v-v830-tau_g430l_archival.yaml
+++ b/utils/data/stis_configs/v-v830-tau_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  o8ns06010_crj.fits:
+    targets:
+      v-v830-tau:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-169_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-169_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60h020_crj.fits:
+    targets:
+      vfts-169:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-169_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-169_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60h010_crj.fits:
+    targets:
+      vfts-169:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-190_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-190_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec62c010_crj.fits:
+    targets:
+      vfts-190:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-267_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-267_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60l020_crj.fits:
+    targets:
+      vfts-267:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-267_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-267_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60l010_crj.fits:
+    targets:
+      vfts-267:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-404_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-404_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60r020_crj.fits:
+    targets:
+      vfts-404:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-404_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-404_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60r010_crj.fits:
+    targets:
+      vfts-404:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-406_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-406_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61v020_crj.fits:
+    targets:
+      vfts-406:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-406_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-406_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec61v010_crj.fits:
+    targets:
+      vfts-406:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-482_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-482_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec699020_crj.fits:
+    targets:
+      vfts-482:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-482_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-482_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec699010_crj.fits:
+    targets:
+      vfts-482:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-542_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-542_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60a020_crj.fits:
+    targets:
+      vfts-542:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-542_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-542_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60a010_crj.fits:
+    targets:
+      vfts-542:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-545_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-545_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60b020_crj.fits:
+    targets:
+      vfts-545:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-545_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-545_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60b010_crj.fits:
+    targets:
+      vfts-545:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-586_g230lb_archival.yaml
+++ b/utils/data/stis_configs/vfts-586_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60z020_crj.fits:
+    targets:
+      vfts-586:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-586_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-586_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60z010_crj.fits:
+    targets:
+      vfts-586:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/vfts-72_g430l_archival.yaml
+++ b/utils/data/stis_configs/vfts-72_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60j010_crj.fits:
+    targets:
+      vfts-72:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/w61-28-5_g230lb_archival.yaml
+++ b/utils/data/stis_configs/w61-28-5_g230lb_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60x020_crj.fits:
+    targets:
+      w61-28-5:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null

--- a/utils/data/stis_configs/w61-28-5_g430l_archival.yaml
+++ b/utils/data/stis_configs/w61-28-5_g430l_archival.yaml
@@ -1,0 +1,15 @@
+force_dq16: true
+infile:
+  oec60x010_crj.fits:
+    targets:
+      w61-28-5:
+        do_defringe: false
+        x1d:
+          b_bkg1: null
+          b_bkg2: null
+          b_hgt1: null
+          b_hgt2: null
+          height: null
+          maxsrch: null
+          xoffset: null
+          yloc: null


### PR DESCRIPTION
These were targets for which the testers found the automatically produced YAML files worked just fine. It was never specified who would commit these to the repo so some were missed and are being added now.