### PR TITLE
Minor timeseries config fixes

### DIFF
--- a/utils/data/timeseries/cvso-90_cos.yaml
+++ b/utils/data/timeseries/cvso-90_cos.yaml
@@ -31,7 +31,6 @@ bins: null
 good_files:
     - le9j4c
     - lccp04
-    - lccp04
 
 # If you want to specify the list of exposures *NOT TO USE*, list them below
 # with the bad_files variable. Otherwise set bad_files to None by using

--- a/utils/data/timeseries/v-ru-lup_cos.yaml
+++ b/utils/data/timeseries/v-ru-lup_cos.yaml
@@ -72,7 +72,6 @@ good_files:
     - leit1k
     - leit1m
     - leit1n
-    - leitae
     - lbgj53lkq
     - lbgj53lmq
     - lbgj53lqq


### PR DESCRIPTION
Remove one duplicated file, and remove one file which is not an actual HST exposure at all. No idea how that one got in there.