### PR TITLE
Use pure python publish workflow to avoid unnecessary wheel building

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
     with:
       upload_to_pypi: ${{ (github.event_name == 'release') && (github.event.action == 'released') && startsWith(github.ref, 'refs/tags/v') }}
     secrets:


### PR DESCRIPTION
Failures in github actions due to a workflow meant for python+(C/other) code which builds unnecessary wheels. This should remove the failures.