### PR TITLE
Add version metadata to pkg dunder

### DIFF
--- a/src/ullyses_utils/__init__.py
+++ b/src/ullyses_utils/__init__.py
@@ -1,0 +1,4 @@
+from importlib.metadata import version
+
+__version__ = version(__name__)
+


### PR DESCRIPTION
The version listed in the pyproject.toml should now be accessible using `ullyses_utils.__version__`